### PR TITLE
Wrong translation

### DIFF
--- a/aspnetcore/security/authorization/limitingidentitybyscheme.md
+++ b/aspnetcore/security/authorization/limitingidentitybyscheme.md
@@ -17,7 +17,7 @@ ms.lasthandoff: 03/22/2018
 ---
 # <a name="authorize-with-a-specific-scheme-in-aspnet-core"></a>Autorizzazione con uno schema specifico in ASP.NET Core
 
-In alcuni scenari, come applicazioni a pagina singola (SPAs), è infrequente l'utilizzo di più metodi di autenticazione. Ad esempio, l'app può utilizzare l'autenticazione basata su cookie di accesso e l'autenticazione della connessione JWT per le richieste di JavaScript. In alcuni casi, l'app può avere più istanze di un gestore di autenticazione. Ad esempio, due gestori di cookie in cui uno contiene un'identità di base e uno viene creato quando un'autenticazione a più fattori (MFA) è stata attivata. Autenticazione a più fattori può essere attivata perché l'utente ha richiesto un'operazione che richiede una maggiore sicurezza.
+In alcuni scenari, come applicazioni a pagina singola (SPAs), è frequente l'utilizzo di più metodi di autenticazione. Ad esempio, l'app può utilizzare l'autenticazione basata su cookie di accesso e l'autenticazione della connessione JWT per le richieste di JavaScript. In alcuni casi, l'app può avere più istanze di un gestore di autenticazione. Ad esempio, due gestori di cookie in cui uno contiene un'identità di base e uno viene creato quando un'autenticazione a più fattori (MFA) è stata attivata. Autenticazione a più fattori può essere attivata perché l'utente ha richiesto un'operazione che richiede una maggiore sicurezza.
 
 # <a name="aspnet-core-2xtabaspnetcore2x"></a>[ASP.NET Core 2.x](#tab/aspnetcore2x)
 


### PR DESCRIPTION
Correct a wrong word: on Italian the term "common" is translated as "frequente" and not "INfrequente"